### PR TITLE
feat(ale): add ALE integration for PsyC lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,54 @@
 # vim-asterios
 
 This repository contains [ViM][1] and [NeoViM][2] support for the following
-languages used when developing an [Asterios Application][3]:
+languages used when developing an [ASTERIOS Application][3]:
 
 * the PsyC (support of the `.psy` files);
 * the KhiC (support of the `.khic` files);
 * the Bgt (support of the `.bgt` files);
 * the tak (support of the `.tak` files).
 
+It also features an integration with [ALE][5] to provide linting of PsyC source
+files.
+
 ## Installation
 
-Use your favorite package manager to install this plug-in. We advise to use
-[vim-plug][4]. Add the following to your vim configuration file:
+Use your favorite package manager to install this plug-in. [vim-plug][4] is
+recommended. Add the following to your vim configuration file:
 
-```vimrc
+```vim
 Plug 'krono-safe/vim-asterios'
 ```
 
 and then, after re-launching ViM, run:
 
-```vimrc
+```vim
 :PlugInstall
 ```
 
+## PsyC Linting
+
+![Screenshot of a Gvim window showing a syntax error in a PsyC file](https://user-images.githubusercontent.com/8275119/82766994-2d0c1800-9e24-11ea-8b1a-e3a3a96f0582.png)
+
+To enable linting of PsyC source files, you need the [ALE][5] plug-in. The
+linting is performed by running `psyko module`, thus you need to provide some
+configuration for the command to work. For example:
+
+```vim
+" local variable: root Krono-Safe installation directory
+let s:ks_dir = 'C:\Program Files (x86)\Krono-Safe'
+
+" full path to psyko.exe
+let g:ale_psy_psyko_executable = s:ks_dir . '\psyko-8.10.2\bin\psyko.exe'
+
+" default product is ksim, but you can override this if you want
+" let g:ale_psy_psyko_product = 'power-mpc5777m-module'
+
+" kernel-dir path (--kernel-dir argument)
+let g:ale_psy_psyko_kernel_dir = s:ks_dir . '\ksim-8.10.2'
+```
+
+For more information, see `:help vim-asterios-lint`.
 
 ## Contributing
 
@@ -32,8 +58,9 @@ Please refer to the file [CONTRIBUTING.md](CONTRIBUTING.md).
 
 This repository is under the [Apache-V2 license](LICENSE).
 
-
 [1]: https://www.vim.org/
 [2]: https://neovim.io/
 [3]: http://www.krono-safe.com/
 [4]: https://github.com/junegunn/vim-plug
+[5]: https://github.com/dense-analysis/ale
+

--- a/ale_linters/psy/psyko.vim
+++ b/ale_linters/psy/psyko.vim
@@ -5,6 +5,7 @@ call ale#Set('psy_psyko_executable', 'psyko')
 call ale#Set('psy_psyko_product', 'ksim')
 call ale#Set('psy_psyko_kernel_dir', '')
 call ale#Set('psy_psyko_options', '--color no')
+call ale#Set('psy_psyko_jsonconf', [])
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -40,19 +41,39 @@ function! s:GetCommand(buffer) abort
     let l:tmpoutputdb = tempname() . '.ks'
     call ale#command#ManageFile(a:buffer, l:tmpoutputdb)
 
-    return '%e '
+    let s:cmdline = '%e '
     \   . ale#Var(a:buffer, 'psy_psyko_options')
     \   . ' --product ' . ale#Var(a:buffer, 'psy_psyko_product')
     \   . ' --kernel-dir ' . ale#Var(a:buffer, 'psy_psyko_kernel_dir')
     \   . ' module --gendb'
     \   . ' --output ' . l:tmpoutputdb
     \   . ' -- ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p'))
+
+
+    " get the content of psy_psyko_jsonconf, and append it to the command line,
+    " if provided
+    let l:jsonconf = ale#Var(a:buffer, 'psy_psyko_jsonconf')
+    if !empty(l:jsonconf)
+        if type(l:jsonconf) == v:t_list
+            for l:jsonfile in l:jsonconf
+                let s:cmdline = s:cmdline . ' ' . ale#Escape(l:jsonfile)
+            endfor
+        elseif type(l:jsonconf) == v:t_string
+            let s:cmdline = s:cmdline . ' ' . l:jsonconf
+        endif
+    endif
+
+    return s:cmdline
 endfunction
 
 
 function! s:HandleOutput(buffer, lines) abort
     let l:output = []
 
+    " try to find out errors from GCC preprocessor
+    call extend(l:output, ale#handlers#gcc#HandleGCCFormat(a:buffer, a:lines))
+
+    " now look for error specifically issued by psyko
     for l:match in ale#util#GetMatches(a:lines, s:psyko_error_regex)
         " ignore the root error messages that just says 'compilation failed'
         if match(l:match[7], s:psyko_root_error_msg_regex) != -1

--- a/ale_linters/psy/psyko.vim
+++ b/ale_linters/psy/psyko.vim
@@ -1,0 +1,85 @@
+" Description: Integration with ALE to run psyko as a linter
+" Version: Compatible with ASTERIOS Developer K19.2
+
+call ale#Set('psy_psyko_executable', 'psyko')
+call ale#Set('psy_psyko_product', 'ksim')
+call ale#Set('psy_psyko_kernel_dir', '')
+call ale#Set('psy_psyko_options', '--color no')
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+let s:psyko_error_regex =
+            \ '\v\w+\>(fatal|error|warning)\>' .
+            \ '\s+(\w+):\s+((.*):(\d+):(\d+):\s+)?(.*)$'
+
+let s:psyko_log_msglevel = {
+                    \ 'fatal': 'E',
+                    \ 'error': 'E',
+                    \ 'warning': 'W',
+                    \ '': 'E'
+                    \}
+
+let s:psyko_root_error_msg_regex = '\v\(faulty command below\):'
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+function! s:GetExecutable(buffer) abort
+    let l:exec = ale#Var(a:buffer, 'psy_psyko_executable')
+
+    " TODO: handle gracefuly error cases:
+    "
+    "   - incorrect psyko version
+    "   - psy_psyko_kernel_dir doesn't exist
+
+    return l:exec
+endfunction
+
+
+function! s:GetCommand(buffer) abort
+    " prepare a temp file for the output db
+    let l:tmpoutputdb = tempname() . '.ks'
+    call ale#command#ManageFile(a:buffer, l:tmpoutputdb)
+
+    return '%e '
+    \   . ale#Var(a:buffer, 'psy_psyko_options')
+    \   . ' --product ' . ale#Var(a:buffer, 'psy_psyko_product')
+    \   . ' --kernel-dir ' . ale#Var(a:buffer, 'psy_psyko_kernel_dir')
+    \   . ' module --gendb'
+    \   . ' --output ' . l:tmpoutputdb
+    \   . ' -- ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p'))
+endfunction
+
+
+function! s:HandleOutput(buffer, lines) abort
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, s:psyko_error_regex)
+        " ignore the root error messages that just says 'compilation failed'
+        if match(l:match[7], s:psyko_root_error_msg_regex) != -1
+            continue
+        endif
+
+        call add(l:output, {
+                    \   'lnum': l:match[5] + 0,
+                    \   'col': l:match[6] + 0,
+                    \   'text': l:match[7],
+                    \   'detail': l:match[2] . ': ' . l:match[7],
+                    \   'code': l:match[2],
+                    \   'type': s:psyko_log_msglevel[l:match[1]],
+                    \})
+    endfor
+
+    return l:output
+endfunction
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+call ale#linter#Define('psy', {
+\   'name': 'psyko',
+\   'output_stream': 'stderr',
+\   'lint_file': 1,
+\   'executable': function('s:GetExecutable'),
+\   'command': function('s:GetCommand'),
+\   'callback': function('s:HandleOutput'),
+\})
+

--- a/doc/asterios.txt
+++ b/doc/asterios.txt
@@ -1,4 +1,4 @@
-*asterios.txt*	ViM/Neovim integration for the ASTERIOS tool suite
+*asterios.txt*                  Vim/Neovim integration for the ASTERIOS tool suite
                                                                                ~
                                    //////////////////(                       ~
                               *///////////////////////////                   ~
@@ -95,6 +95,17 @@ g:ale_psy_psyko_options                              *g:ale_psy_psyko_options*
   Default: `--color no`
 
   Option flags used when invoking `psyko`.
+
+
+g:ale_psy_psyko_jsonconf                            *g:ale_psy_psyko_jsonconf*
+                                                    *b:ale_psy_psyko_jsonconf*
+
+  Type: |List| or |String|
+  Default: `[]`
+
+  Additional JSON/Hjson configuration files that `psyko` must use for linting.
+  These files are added to the `psyko module` command line: make sure to use
+  configuration models accepted for the `module` command in your JSON files.
 
 ==============================================================================
   vim:tw=78:ts=8:noet:ft=help

--- a/doc/asterios.txt
+++ b/doc/asterios.txt
@@ -1,0 +1,100 @@
+*asterios.txt*	ViM/Neovim integration for the ASTERIOS tool suite
+                                                                               ~
+                                   //////////////////(                       ~
+                              *///////////////////////////                   ~
+                           *///*******/%#&&&&&&&&%/*/////////.               ~
+                         ********/####%%%%%%%%&&&&&&&&&////////(             ~
+                        *******########%%%%%%%%%&&&&&&&&&%///////            ~
+                      *//****###########%%%%%%%%%%&&&&&&&&&%//////.          ~
+                     */////*############%%%%%%%%%%%%&&&&&&&&&,,,,,*.         ~
+                     /////*(############%%%%%%%%%%%%%&&&&&&&&&,,,,,,         ~
+                    */////*(####%&@@@@@@@@@@&&@@%%%%%%&&&&&&&&,,,,,,/        ~
+              *%&&@@@@@@@@@%(*.................*@%#%%%&&&&&&&&(*****%        ~
+    &&&&&&(,,..................................@@#%%%%%&&&&&&&******&        ~
+    &&&&&&&&&&&&&&&&&&&@@@@@@@@@@@@@@@@@...../@@#%%%%%%&&&&&&&***/**&        ~
+                     .,,,,..**######(@@.....@@#%%%%%%%&&&&&&&**////&         ~
+                      ,,,,,..***###(@@....(@@#%%%%%%&&&&&&&(*/////&,         ~
+                        *,,,,,,***#@@....@@%%%%%%%&&&&&&&(**/////&           ~
+                         ,*,,,,,,,@@...(@@##%%%&&&&&&&#**//////&,            ~
+                            /,,*,&&...@@#%%%%&&&%/****////(/(&               ~
+                               /%&..(@&**********////////(&                  ~
+                               &&..&&**/////////////(%(                      ~
+                              &&//&&%%*                                      ~
+                               (%%%%%                                        ~
+                                                                             ~
+            #     #####  ####### ####### ######  ### #######  #####  ~
+           # #   #     #    #    #       #     #  #  #     # #     # ~
+          #   #  #          #    #       #     #  #  #     # #       ~
+         #     #  #####     #    #####   ######   #  #     #  #####  ~
+         #######       #    #    #       #   #    #  #     #       # ~
+         #     # #     #    #    #       #    #   #  #     # #     # ~
+         #     #  #####     #    ####### #     # ### #######  #####  ~
+
+==============================================================================
+Overview                                                        *vim-asterios*
+
+vim-asterios provides support for the languages used when developing an
+ASTERIOS application:
+
+  * the PsyC (support of the `.psy` files);
+  * the KhiC (support of the `.khic` files);
+  * the Bgt (support of the `.bgt` files);
+  * the tak (support of the `.tak` files).
+
+It also features an integration with ALE to provide linting of PsyC source
+files, for ASTERIOS Developer K19.2 and above only: see |vim-asterios-lint|.
+
+==============================================================================
+ALE Psy Integration                                        *vim-asterios-lint*
+                                                             *ale-psy-options*
+
+ALE (Asynchronous Lint Engine) can lint PsyC source files using `psyko`. You
+need the ALE plugin obviously, and you also need to redefine the following
+variables:
+
+  * |g:ale_psy_psyko_executable|
+  * |g:ale_psy_psyko_product|
+  * |g:ale_psy_psyko_kernel_dir|
+
+------------------------------------------------------------------------------
+
+g:ale_psy_psyko_executable                        *g:ale_psy_psyko_executable*
+                                                  *b:ale_psy_psyko_executable*
+
+  Type: |String|
+  Default: `psyko`
+
+  Complete path to `psyko` executable, version must be 8.10.2 or above.
+
+
+g:ale_psy_psyko_product                              *g:ale_psy_psyko_product*
+                                                     *b:ale_psy_psyko_product*
+
+  Type: |String|
+  Default: `ksim`
+
+  Value of the `--product` option used when invoking `psyko`.
+
+
+g:ale_psy_psyko_kernel_dir                        *g:ale_psy_psyko_kernel_dir*
+                                                  *b:ale_psy_psyko_kernel_dir*
+
+  Type: |String|
+  Default: `''`
+
+  Value of the `--kernel-dir` option used when invoking `psyko`.
+
+  Note: The default value is invalid, thus the integration cannot work unless
+  you override this variable.
+
+
+g:ale_psy_psyko_options                              *g:ale_psy_psyko_options*
+                                                     *b:ale_psy_psyko_options*
+
+  Type: |String|
+  Default: `--color no`
+
+  Option flags used when invoking `psyko`.
+
+==============================================================================
+  vim:tw=78:ts=8:noet:ft=help

--- a/ftplugin/psy.vim
+++ b/ftplugin/psy.vim
@@ -11,4 +11,5 @@ endif
 " Psy is built on top of C. Let source first the ftplugin files associated
 " with the C language.
 runtime! ftplugin/c.vim ftplugin/c_*.vim ftplugin/c/*.vim
+
 let b:did_ftplugin = 1

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,4 @@
+# Note
+
+This directory groups some test files meant to be used for quick analysis during
+development. An automated test suite is not available (yet).

--- a/tests/psy/flags.psymodule.json
+++ b/tests/psy/flags.psymodule.json
@@ -1,0 +1,8 @@
+{
+  "psymodule":{
+    "psy_pp_flags": [
+      "-D",
+      "CPP_SYMBOL_IN_JSON"
+    ]
+  }
+}

--- a/tests/psy/sourceme.vim
+++ b/tests/psy/sourceme.vim
@@ -1,0 +1,6 @@
+" Description: Source this to define `psy_psyko_jsonconf`. Linting of
+"              wrong-syntax.psy should succeed with no error reported
+
+
+let s:here_dir = expand('<sfile>:p:h')
+let g:ale_psy_psyko_jsonconf = s:here_dir . '/flags.psymodule.json'

--- a/tests/psy/wrong-syntax.psy
+++ b/tests/psy/wrong-syntax.psy
@@ -1,0 +1,37 @@
+/**
+ * This file has different PsyC syntax errors commented-out. Uncomment them and
+ * make sure that the linter detects them.
+ */
+
+#include <asterios.h>
+// #include <missing_header.h>
+
+/* CPP_SYMBOL_IN_JSON is defined in flags.psymodule.json. If you've set
+ * g:ale_psy_psyko_jsonconf correctly, this block should not throw an error */
+#ifndef CPP_SYMBOL_IN_JSON
+# error iflags are missing
+#endif
+
+// #error throw an error
+
+clock c1 = ast_realtime_ms;
+
+temporal int my_temporal with c1;
+
+agent Smith (// syntax_error,
+    uses realtime, starttime 1 with c1, defaultclock c1)
+{
+  consult
+  {
+    1$my_temporal;
+  }
+
+  body start
+  {
+    int i = $[1]my_temporal;
+    // int j = $[1]other_temporal;
+
+    advance 1 with c1;
+    // advance 1 with c2;
+  }
+}


### PR DESCRIPTION
- Integrate with ALE to run `psyko module --gendb` and lint `.psy`
  source files
- Add a vim documentation: run `:help asterios`
- Additional info and some refactor in README