### PR TITLE
feat(ale): enable to change psyko path dynamically

### DIFF
--- a/ale_linters/psy/psyko.vim
+++ b/ale_linters/psy/psyko.vim
@@ -105,7 +105,7 @@ call ale#linter#Define('psy', {
 \   'name': 'psyko',
 \   'output_stream': 'stderr',
 \   'lint_file': 1,
-\   'executable': g:ast_psyko_path,
+\   'executable': { -> g:ast_psyko_path},
 \   'command': function('s:GetCommand'),
 \   'callback': function('s:HandleOutput'),
 \})


### PR DESCRIPTION
The path to _psyko_ was read once at during the setup of _ale_: the user cannot change it afterwards, even if they change `g:ast_psyko_path`. This minor patch enables just that.